### PR TITLE
enable push notifications for android

### DIFF
--- a/packages/intercom-react-native/build/withIntercom.d.ts
+++ b/packages/intercom-react-native/build/withIntercom.d.ts
@@ -21,6 +21,10 @@ export interface IntercomPluginPropsAndroid {
      * Intercom app id
      */
     androidApiKey?: string;
+    /**
+     * Enable push notifications for Android
+     */
+    isPushNotificationsEnabledAndroid?: boolean;
 }
 export interface IntercomPluginProps extends IntercomPluginPropsIOS, IntercomPluginPropsAndroid {
     /**

--- a/packages/intercom-react-native/build/withIntercomAndroid.js
+++ b/packages/intercom-react-native/build/withIntercomAndroid.js
@@ -23,13 +23,13 @@ async function saveFileAsync(path, content) {
 }
 function getMainNotificationService(packageName) {
     return `package ${packageName};
-import com.google.firebase.messaging.FirebaseMessagingService;
+import expo.modules.notifications.service.ExpoFirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 import com.intercom.reactnative.IntercomModule;
 
-public class MainNotificationService extends FirebaseMessagingService {
+public class MainNotificationService extends ExpoFirebaseMessagingService {
 
-  @Override 
+  @Override
   public void onNewToken(String refreshedToken) {
     IntercomModule.sendTokenToIntercom(getApplication(), refreshedToken);
     super.onNewToken(refreshedToken);
@@ -45,20 +45,19 @@ public class MainNotificationService extends FirebaseMessagingService {
   }
 }`;
 }
-const withIntercomAndroid = (config, { intercomEURegion, androidApiKey, appId }) => {
-    const isPushNotificationsEnabled = false;
+const withIntercomAndroid = (config, { intercomEURegion, androidApiKey, appId, isPushNotificationsEnabledAndroid = false }) => {
     config = (0, exports.withIntercomAndroidManifest)(config, {
         EURegion: intercomEURegion,
-        pushNotifications: isPushNotificationsEnabled,
+        pushNotifications: isPushNotificationsEnabledAndroid,
     });
     config = (0, exports.withIntercomAppBuildGradle)(config, {
-        pushNotifications: isPushNotificationsEnabled,
+        pushNotifications: isPushNotificationsEnabledAndroid,
     });
     config = (0, exports.withIntercomMainApplication)(config, {
         appId,
         apiKey: androidApiKey,
     });
-    if (isPushNotificationsEnabled) {
+    if (isPushNotificationsEnabledAndroid) {
         config = withIntercomMainNotificationService(config, {});
         config = withIntercomProjectBuildGradle(config, {});
     }

--- a/packages/intercom-react-native/src/withIntercom.ts
+++ b/packages/intercom-react-native/src/withIntercom.ts
@@ -27,9 +27,9 @@ export interface IntercomPluginPropsAndroid {
    */
   androidApiKey?: string;
   /**
-   * Enable push notifications for iOS
+   * Enable push notifications for Android
    */
-  //  isPushNotificationsEnabledAndroid?: boolean;
+   isPushNotificationsEnabledAndroid?: boolean;
 }
 
 // TODO: Add in built in push support

--- a/packages/intercom-react-native/src/withIntercomAndroid.ts
+++ b/packages/intercom-react-native/src/withIntercomAndroid.ts
@@ -34,13 +34,13 @@ async function saveFileAsync(path: string, content: string) {
 
 function getMainNotificationService(packageName: string) {
   return `package ${packageName};
-import com.google.firebase.messaging.FirebaseMessagingService;
+import expo.modules.notifications.service.ExpoFirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 import com.intercom.reactnative.IntercomModule;
 
-public class MainNotificationService extends FirebaseMessagingService {
+public class MainNotificationService extends ExpoFirebaseMessagingService {
 
-  @Override 
+  @Override
   public void onNewToken(String refreshedToken) {
     IntercomModule.sendTokenToIntercom(getApplication(), refreshedToken);
     super.onNewToken(refreshedToken);
@@ -59,22 +59,21 @@ public class MainNotificationService extends FirebaseMessagingService {
 
 export const withIntercomAndroid: ConfigPlugin<IntercomPluginProps> = (
   config,
-  { intercomEURegion, androidApiKey, appId }
+  { intercomEURegion, androidApiKey, appId, isPushNotificationsEnabledAndroid = false }
 ) => {
-  const isPushNotificationsEnabled = false;
   config = withIntercomAndroidManifest(config, {
     EURegion: intercomEURegion,
-    pushNotifications: isPushNotificationsEnabled,
+    pushNotifications: isPushNotificationsEnabledAndroid,
   });
   config = withIntercomAppBuildGradle(config, {
-    pushNotifications: isPushNotificationsEnabled,
+    pushNotifications: isPushNotificationsEnabledAndroid,
   });
   config = withIntercomMainApplication(config, {
     appId,
     apiKey: androidApiKey as string,
   });
 
-  if (isPushNotificationsEnabled) {
+  if (isPushNotificationsEnabledAndroid) {
     config = withIntercomMainNotificationService(config, {});
     config = withIntercomProjectBuildGradle(config, {});
   }


### PR DESCRIPTION
This PR fixes https://github.com/cmaycumber/config-plugin-react-native-intercom/issues/25

This will work if you use the Expo push notifications service. I'm not sure how it would interact with other services such as Customer.IO.