### PR TITLE
add android icon customization functionality

### DIFF
--- a/packages/intercom-react-native/build/withIntercom.d.ts
+++ b/packages/intercom-react-native/build/withIntercom.d.ts
@@ -21,6 +21,13 @@ export interface IntercomPluginPropsAndroid {
      * Intercom app id
      */
     androidApiKey?: string;
+    /**
+     * Enable push notifications for iOS
+     */
+    /**
+     * Customize the icon for intercom push notifications from the intercom default
+     */
+    androidIcon?: string;
 }
 export interface IntercomPluginProps extends IntercomPluginPropsIOS, IntercomPluginPropsAndroid {
     /**

--- a/packages/intercom-react-native/build/withIntercomAndroid.js
+++ b/packages/intercom-react-native/build/withIntercomAndroid.js
@@ -17,7 +17,6 @@ const DPI_VALUES = {
     xxxhdpi: { folderName: 'drawable-xxxhdpi', scale: 4 },
 };
 const BASELINE_PIXEL_SIZE = 24;
-const INTERCOM_PUSH_ICON_NAME = 'intercom_push_icon';
 const { addMetaDataItemToMainApplication, getMainApplicationOrThrow } = config_plugins_1.AndroidConfig.Manifest;
 function getPackageRoot(projectRoot) {
     return path_1.default.join(projectRoot, "android", "app", "src", "main", "java");
@@ -258,7 +257,7 @@ async function savePushIcon(projectRoot, iconPath) {
                 resizeMode: 'cover',
                 backgroundColor: 'transparent',
             })).source;
-            (0, fs_1.writeFileSync)(path_1.default.resolve(dpiFolderPath, INTERCOM_PUSH_ICON_NAME + '.png'), resizedIcon);
+            (0, fs_1.writeFileSync)(path_1.default.resolve(dpiFolderPath, 'intercom_push_icon.png'), resizedIcon);
         }
         catch (e) {
             throw new Error('Encountered an issue resizing Android notification icon: ' + e);

--- a/packages/intercom-react-native/src/withIntercom.ts
+++ b/packages/intercom-react-native/src/withIntercom.ts
@@ -30,6 +30,10 @@ export interface IntercomPluginPropsAndroid {
    * Enable push notifications for iOS
    */
   //  isPushNotificationsEnabledAndroid?: boolean;
+  /**
+   * Customize the icon for intercom push notifications from the intercom default
+   */
+  androidIcon?: string;
 }
 
 // TODO: Add in built in push support

--- a/packages/intercom-react-native/src/withIntercomAndroid.ts
+++ b/packages/intercom-react-native/src/withIntercomAndroid.ts
@@ -12,7 +12,18 @@ import {
 import type { IntercomPluginProps } from "./withIntercom";
 import { mergeContents } from "@expo/config-plugins/build/utils/generateCode";
 import path from "path";
-import { promises as fs } from "fs";
+import { promises as fs, existsSync, mkdirSync, writeFileSync } from "fs";
+import { generateImageAsync } from '@expo/image-utils'
+
+const DPI_VALUES = {
+  mdpi: { folderName: 'drawable-mdpi', scale: 1 },
+  hdpi: { folderName: 'drawable-hdpi', scale: 1.5 },
+  xhdpi: { folderName: 'drawable-xhdpi', scale: 2 },
+  xxhdpi: { folderName: 'drawable-xxhdpi', scale: 3 },
+  xxxhdpi: { folderName: 'drawable-xxxhdpi', scale: 4 },
+}
+const BASELINE_PIXEL_SIZE = 24
+const INTERCOM_PUSH_ICON_NAME = 'intercom_push_icon'
 
 const { addMetaDataItemToMainApplication, getMainApplicationOrThrow } = AndroidConfig.Manifest;
 
@@ -40,7 +51,7 @@ import com.intercom.reactnative.IntercomModule;
 
 public class MainNotificationService extends FirebaseMessagingService {
 
-  @Override 
+  @Override
   public void onNewToken(String refreshedToken) {
     IntercomModule.sendTokenToIntercom(getApplication(), refreshedToken);
     super.onNewToken(refreshedToken);
@@ -59,7 +70,7 @@ public class MainNotificationService extends FirebaseMessagingService {
 
 export const withIntercomAndroid: ConfigPlugin<IntercomPluginProps> = (
   config,
-  { intercomEURegion, androidApiKey, appId }
+  { intercomEURegion, androidApiKey, appId, androidIcon }
 ) => {
   const isPushNotificationsEnabled = false;
   config = withIntercomAndroidManifest(config, {
@@ -77,6 +88,9 @@ export const withIntercomAndroid: ConfigPlugin<IntercomPluginProps> = (
   if (isPushNotificationsEnabled) {
     config = withIntercomMainNotificationService(config, {});
     config = withIntercomProjectBuildGradle(config, {});
+  }
+  if (androidIcon) {
+    config = withNotificationIcons(config, {androidIcon})
   }
   return config;
 };
@@ -291,4 +305,49 @@ async function setEURegionTrueAsync(
   );
 
   return androidManifest;
+}
+
+
+
+const withNotificationIcons: ConfigPlugin<{
+  androidIcon: string;
+}> = (config, { androidIcon }) => {
+  return withDangerousMod(config, [
+    'android',
+    async (config) => {
+      await savePushIcon(config.modRequest.projectRoot, androidIcon)
+      return config
+    },
+  ])
+}
+
+async function savePushIcon(projectRoot: string, iconPath: string) {
+  await Promise.all(
+    Object.values(DPI_VALUES).map(async ({ folderName, scale }) => {
+      const resourcesPath = await AndroidConfig.Paths.getResourceFolderAsync(projectRoot)
+      const dpiFolderPath = path.resolve(projectRoot, resourcesPath, folderName)
+      if (!existsSync(dpiFolderPath)) {
+        mkdirSync(dpiFolderPath, { recursive: true })
+      }
+      const iconSizePx = BASELINE_PIXEL_SIZE * scale
+
+      try {
+        const resizedIcon = (
+          await generateImageAsync(
+            { projectRoot, cacheType: 'android-notification' },
+            {
+              src: iconPath,
+              width: iconSizePx,
+              height: iconSizePx,
+              resizeMode: 'cover',
+              backgroundColor: 'transparent',
+            }
+          )
+        ).source
+        writeFileSync(path.resolve(dpiFolderPath, INTERCOM_PUSH_ICON_NAME + '.png'), resizedIcon)
+      } catch (e) {
+        throw new Error('Encountered an issue resizing Android notification icon: ' + e)
+      }
+    })
+  )
 }

--- a/packages/intercom-react-native/src/withIntercomAndroid.ts
+++ b/packages/intercom-react-native/src/withIntercomAndroid.ts
@@ -23,7 +23,6 @@ const DPI_VALUES = {
   xxxhdpi: { folderName: 'drawable-xxxhdpi', scale: 4 },
 }
 const BASELINE_PIXEL_SIZE = 24
-const INTERCOM_PUSH_ICON_NAME = 'intercom_push_icon'
 
 const { addMetaDataItemToMainApplication, getMainApplicationOrThrow } = AndroidConfig.Manifest;
 
@@ -307,8 +306,6 @@ async function setEURegionTrueAsync(
   return androidManifest;
 }
 
-
-
 const withNotificationIcons: ConfigPlugin<{
   androidIcon: string;
 }> = (config, { androidIcon }) => {
@@ -344,7 +341,7 @@ async function savePushIcon(projectRoot: string, iconPath: string) {
             }
           )
         ).source
-        writeFileSync(path.resolve(dpiFolderPath, INTERCOM_PUSH_ICON_NAME + '.png'), resizedIcon)
+        writeFileSync(path.resolve(dpiFolderPath, 'intercom_push_icon.png'), resizedIcon)
       } catch (e) {
         throw new Error('Encountered an issue resizing Android notification icon: ' + e)
       }


### PR DESCRIPTION
Intercom explains how to customize the icon in their [android setup docs](https://developers.intercom.com/installing-intercom/docs/android-fcm-push-notifications).

I've followed a similar implementation to how it was done by [expo-notifications](https://github.com/expo/expo/blob/main/packages/expo-notifications/plugin/src/withNotificationsAndroid.ts)

I've not managed to figure out how to customize the icon color. Awaiting some clarification from intercom