### PR TITLE
Stop overwriting build properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Open your `app.json` and update your `plugins` section:
   "plugins": [
     [
       "expo-build-properties",
-      { "android": { "compileSdkVersion": 33, "targetSdkVersion": 33 } },
+      { "android": { "compileSdkVersion": 33, "targetSdkVersion": 33 } }
     ],
     "config-plugin-react-native-intercom"
   ]

--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -30,6 +30,10 @@
     },
     "plugins": [
       [
+        "expo-build-properties",
+        { "android": { "compileSdkVersion": 33, "targetSdkVersion": 33 } }
+      ],
+      [
         "config-plugin-react-native-intercom",
         {
           "iosApiKey": "myIosApiKey",

--- a/packages/intercom-react-native/package.json
+++ b/packages/intercom-react-native/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@expo/config-plugins": "^5.0.4",
-    "expo-build-properties": "^0.4.1",
     "semver": "^7.3.8"
   },
   "peerDependencies": {

--- a/packages/intercom-react-native/src/withIntercom.ts
+++ b/packages/intercom-react-native/src/withIntercom.ts
@@ -1,9 +1,4 @@
-import {
-  ConfigPlugin,
-  createRunOncePlugin,
-  withPlugins,
-} from "@expo/config-plugins";
-import { withBuildProperties } from "expo-build-properties";
+import { ConfigPlugin, createRunOncePlugin } from "@expo/config-plugins";
 
 import { withIntercomAndroid } from "./withIntercomAndroid";
 import { withIntercomIOS } from "./withIntercomIOS";
@@ -66,22 +61,6 @@ const withIntercom: ConfigPlugin<IntercomPluginProps> = (config, props) => {
   if (androidApiKey) {
     config = withIntercomAndroid(config, props);
   }
-
-  config = withPlugins(config, [
-    [
-      withBuildProperties,
-      {
-        android: {
-          compileSdkVersion: 31,
-          targetSdkVersion: 31,
-          buildToolsVersion: "31.0.0",
-        },
-        ios: {
-          deploymentTarget: "13.0",
-        },
-      },
-    ],
-  ]);
 
   // Return the modified config.
   return config;


### PR DESCRIPTION
Instead of forcing apps to use specific build properties, just document the requirements

Fixes #51