### PR TITLE
fix: add info about eas secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ You can either:
 
 - use `expo prebuild` or `expo run:android`/`expo run:ios` to update your native projects,
 - use _[EAS Build](https://docs.expo.io/build/introduction/)_ to build your development client.
+  - Keep in mind that if you are using environment variables for `androidApiKey`, `iosApiKey` and `appId` in your `app.config.js`, you need to configure these secrets with `eas secret:create` or at _[Expo](https://expo.dev)_.
 
 ## Contributing
 


### PR DESCRIPTION
Related to https://github.com/cmaycumber/config-plugin-react-native-intercom/issues/38

We previously made the mistake of not configuring the secrets at the Expo servers, which made initialization of intercom in the app impossible. Adding a text to prevent anyone from making the same blunder