### PR TITLE
fix(deps): use a valid `@expo/config-plugins` version for Expo SDK 49

### DIFF
--- a/packages/intercom-react-native/package.json
+++ b/packages/intercom-react-native/package.json
@@ -33,7 +33,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "~6.0.0",
+    "@expo/config-plugins": "~7.2.2",
     "semver": "^7.3.8"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR uses a valid `@expo/config-plugins` version to make it compatible with Expo SDK 49.

Right now, when executing `npx expo-doctor@latest`, developers get the following error:

![Screenshot 2023-08-04 at 17 33 04](https://github.com/cmaycumber/config-plugin-react-native-intercom/assets/11066224/000c527c-6c19-4611-adf7-3680aeb71a6b)

Fixes #62 
