### PR TITLE
Android Notifications : Fix Firebase messaging importation for React Native 0.71 and above - Closes #73

### DIFF
--- a/packages/intercom-react-native/build/withIntercomAndroid.js
+++ b/packages/intercom-react-native/build/withIntercomAndroid.js
@@ -155,9 +155,17 @@ const withIntercomAppBuildGradle = (config, { pushNotifications }) => {
         if (pushNotifications) {
             const firebaseImp = `implementation 'com.google.firebase:firebase-messaging:23.1.+'`;
             if (!config.modResults.contents.includes(firebaseImp)) {
+
                 const anchor = `implementation "com.facebook.react:react-native:+"  // From node_modules`;
-                config.modResults.contents = config.modResults.contents.replace(anchor, `${anchor}
-      ${firebaseImp}`);
+                // In RN 0.71 and beyond, React Native Gradle Plugin is used, so import of firebase has to be adapted
+                if (config.modResults.contents.includes(anchor)) {
+                    config.modResults.contents = config.modResults.contents.replace(anchor, `${anchor}
+        ${firebaseImp}`);
+                } else {
+                    const anchorForReactNative071 = `implementation("com.facebook.react:react-android")`;
+                    config.modResults.contents = config.modResults.contents.replace(anchorForReactNative071, `${anchorForReactNative071}
+        ${firebaseImp}`);
+                }
             }
             const applyPlugin = `apply plugin: 'com.google.gms.google-services'`;
             if (!config.modResults.contents.includes(applyPlugin)) {

--- a/packages/intercom-react-native/src/withIntercomAndroid.ts
+++ b/packages/intercom-react-native/src/withIntercomAndroid.ts
@@ -200,11 +200,21 @@ export const withIntercomAppBuildGradle: ConfigPlugin<{
       const firebaseImp = `implementation 'com.google.firebase:firebase-messaging:23.1.+'`;
       if (!config.modResults.contents.includes(firebaseImp)) {
         const anchor = `implementation "com.facebook.react:react-native:+"  // From node_modules`;
-        config.modResults.contents = config.modResults.contents.replace(
-          anchor,
-          `${anchor}
-      ${firebaseImp}`
-        );
+        // In RN 0.71 and beyond, React Native Gradle Plugin is used, so import of firebase has to be adapted
+        if (config.modResults.contents.includes(anchor)) {
+          config.modResults.contents = config.modResults.contents.replace(
+              anchor,
+              `${anchor}
+        ${firebaseImp}`
+          );
+        } else {
+          const anchorForReactNative071 = `implementation("com.facebook.react:react-android")`;
+          config.modResults.contents = config.modResults.contents.replace(
+              anchorForReactNative071,
+              `${anchorForReactNative071}
+        ${firebaseImp}`
+          );
+        }
       }
 
       const applyPlugin = `apply plugin: 'com.google.gms.google-services'`;


### PR DESCRIPTION
Android Notifications : Fix Firebase messaging importation for React Native 0.71 and above - Closes #73

Needed to upgrade at least for Expo 50

Fix Android Notifications issue https://github.com/cmaycumber/config-plugin-react-native-intercom/issues/73

Needs testing ^^